### PR TITLE
Problem getting correct tableName value from dataset in custom pipeline

### DIFF
--- a/ADFLocalEnvironment/ADFLocalEnvironment.cs
+++ b/ADFLocalEnvironment/ADFLocalEnvironment.cs
@@ -721,7 +721,7 @@ Write-Host ""Finished uploading all ADF Dependencies from $dependencyFolder !"" 
             jsonObject.Add("apiVersion", ARM_API_VERSION);
 
             // need to escape square brackets in Values as they are a special place-holder in ADF
-            jsonObject = jsonObject.ReplaceInValues("[", "[[").ReplaceInValues("]", "]]");
+            // jsonObject = jsonObject.ReplaceInValues("[", "[[").ReplaceInValues("]", "]]");
 
             JArray dependsOn = new JArray();
             dependsOn.Add("[parameters('" + ARM_PROJECT_PARAMETER_NAME + "')]");


### PR DESCRIPTION
This does not work as it only doubles brackets and then they cannot be read by azure service. For example: I had 
        "typeProperties": {
            "tableName": "[dbo].[test]"
        }
-> this would turn it to 
        "typeProperties": {
            "tableName": "[[dbo]].[[test]]"
        }
and it was impossible to connect to my database table as [[dbo]].[[test]] table does not exist (table [dbo].[test] does). You can check this while debugging pipeline code in real-time.